### PR TITLE
Support .app files, expand variables, allow fruitstrap arguments

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ios/connector/DeployBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/DeployBuilder.java
@@ -17,16 +17,19 @@ import java.io.File;
 import java.io.IOException;
 
 public class DeployBuilder extends Builder {
+
     public final String udid;
     public final String path;
+    public final String cmdLineArgs;
 
     @Inject
     private transient iOSDeviceList devices;
 
     @DataBoundConstructor
-    public DeployBuilder(String path,String udid) {
+    public DeployBuilder(String path, String udid, String cmdLineArgs) {
         this.path = path;
         this.udid = udid;
+        this.cmdLineArgs = cmdLineArgs;
     }
 
     @Override
@@ -54,7 +57,7 @@ public class DeployBuilder extends Builder {
             }
 
             listener.getLogger().printf("Deploying iOS app: %s\n", name);
-            dev.deploy(new File(bundle.getRemote()), listener);
+            dev.deploy(new File(bundle.getRemote()), cmdLineArgs, listener);
         }
         return true;
     }

--- a/src/main/java/org/jenkinsci/plugins/ios/connector/DeployTask.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/DeployTask.java
@@ -21,12 +21,14 @@ import java.util.List;
 class DeployTask implements Callable<Void, IOException> {
 
     private final FilePath bundle;
+    private final String cmdLineArgs;
     private final TaskListener listener;
     private final String deviceId;
     private final FilePath rootPath;
 
-    DeployTask(iOSDevice device, File bundle, TaskListener listener) {
+    DeployTask(iOSDevice device, File bundle, String cmdLineArgs, TaskListener listener) {
         this.bundle = new FilePath(bundle);
+        this.cmdLineArgs = cmdLineArgs;
         this.listener = listener;
         this.deviceId = device.getUniqueDeviceId();
         this.rootPath = device.getComputer().getNode().getRootPath();
@@ -65,6 +67,7 @@ class DeployTask implements Callable<Void, IOException> {
 
             ArgumentListBuilder arguments = new ArgumentListBuilder(fruitstrap.getRemote());
             arguments.add("--id", deviceId, "--bundle", appDir.getName());
+            arguments.addTokenized(cmdLineArgs);
 
             ProcStarter proc = new LocalLauncher(listener).launch()
                     .cmds(arguments)

--- a/src/main/java/org/jenkinsci/plugins/ios/connector/DeployTask.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/DeployTask.java
@@ -2,9 +2,11 @@ package org.jenkinsci.plugins.ios.connector;
 
 import hudson.FilePath;
 import hudson.Launcher.LocalLauncher;
+import hudson.Launcher.ProcStarter;
 import hudson.Util;
 import hudson.model.TaskListener;
 import hudson.remoting.Callable;
+import hudson.util.ArgumentListBuilder;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,13 +19,14 @@ import java.util.List;
  * @author Kohsuke Kawaguchi
  */
 class DeployTask implements Callable<Void, IOException> {
-    private final FilePath ipa;
+
+    private final FilePath bundle;
     private final TaskListener listener;
     private final String deviceId;
     private final FilePath rootPath;
 
-    DeployTask(iOSDevice device, File ipa, TaskListener listener) {
-        this.ipa = new FilePath(ipa);
+    DeployTask(iOSDevice device, File bundle, TaskListener listener) {
+        this.bundle = new FilePath(bundle);
         this.listener = listener;
         this.deviceId = device.getUniqueDeviceId();
         this.rootPath = device.getComputer().getNode().getRootPath();
@@ -39,19 +42,37 @@ class DeployTask implements Callable<Void, IOException> {
                 fruitstrap.chmod(0755);
             }
 
-            listener.getLogger().println("Extracting "+ipa+" to "+t);
+            listener.getLogger().println("Copying "+ bundle +" to "+ t);
 
-            ipa.unzip(new FilePath(t));
-            FilePath payloadDir = new FilePath(t).child("Payload");
-            List<FilePath> payload = payloadDir.listDirectories();
-            if (payload==null || payload.isEmpty())
-                throw new IOException("Malformed IPA file: "+ipa);
-            FilePath appDir = payload.get(0);
+            // Determine what type of file was passed
+            FilePath appDir;
+            FilePath tmpDir = new FilePath(t);
+            final String filename = bundle.getName();
+            if (filename.toLowerCase().endsWith(".ipa")) {
+                listener.getLogger().println("Extracting .app from .ipa file...");
+                bundle.unzip(tmpDir);
+                FilePath payloadDir = tmpDir.child("Payload");
+                List<FilePath> payload = payloadDir.listDirectories();
+                if (payload==null || payload.isEmpty())
+                    throw new IOException("Malformed IPA file: "+bundle);
+                appDir = payload.get(0);
+            } else if (filename.toLowerCase().endsWith(".app")) {
+                appDir = tmpDir.child(filename);
+                bundle.copyRecursiveTo(appDir);
+            } else {
+                throw new IOException("Expected either a .app or .ipa bundle!");
+            }
 
-            int exit = new LocalLauncher(listener).launch().cmds(
-                    fruitstrap.getRemote(), "-i", deviceId, "-b", appDir.getName()).stdout(listener).pwd(payloadDir).join();
+            ArgumentListBuilder arguments = new ArgumentListBuilder(fruitstrap.getRemote());
+            arguments.add("--id", deviceId, "--bundle", appDir.getName());
+
+            ProcStarter proc = new LocalLauncher(listener).launch()
+                    .cmds(arguments)
+                    .stdout(listener)
+                    .pwd(appDir.getParent());
+            int exit = proc.join();
             if (exit!=0)
-                throw new IOException("Deployment of "+ipa+" failed: "+exit);
+                throw new IOException("Deployment of "+bundle+" failed: "+exit);
 
             return null;
         } catch (InterruptedException e) {

--- a/src/main/java/org/jenkinsci/plugins/ios/connector/cli/DeployCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/cli/DeployCommand.java
@@ -10,6 +10,7 @@ import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.ios.connector.iOSDevice;
 import org.jenkinsci.plugins.ios.connector.iOSDeviceList;
 import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.Option;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -26,6 +27,9 @@ public class DeployCommand extends CLICommand {
 
     @Argument(index=1,metaVar="BUNDLE",usage="*.ipa/app file(s) to deploy",required=true)
     public List<String> files;
+
+    @Option(name="--args",usage="Arguments to pass to the `fruitstrap` command")
+    public String cmdLineArgs;
 
     @Inject
     iOSDeviceList devices;
@@ -52,7 +56,7 @@ public class DeployCommand extends CLICommand {
         for (String bundle : files) {
             FilePath p = new FilePath(checkChannel(), bundle);
             listener.getLogger().println("Deploying "+ bundle);
-            dev.deploy(new File(p.getRemote()), listener);
+            dev.deploy(new File(p.getRemote()), cmdLineArgs, listener);
         }
         return 0;
     }

--- a/src/main/java/org/jenkinsci/plugins/ios/connector/cli/DeployCommand.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/cli/DeployCommand.java
@@ -24,7 +24,7 @@ public class DeployCommand extends CLICommand {
         usage="Unique device ID or device name",required=true)
     public String device;
 
-    @Argument(index=1,metaVar="IPA",usage="*.ipa files to deploy",required=true)
+    @Argument(index=1,metaVar="BUNDLE",usage="*.ipa/app file(s) to deploy",required=true)
     public List<String> files;
 
     @Inject
@@ -37,7 +37,7 @@ public class DeployCommand extends CLICommand {
 
     @Override
     public String getShortDescription() {
-        return "Deploy IPA files to iOS devices connected to Jenkins";
+        return "Deploy apps to iOS devices connected to Jenkins";
     }
 
     @Override
@@ -49,16 +49,10 @@ public class DeployCommand extends CLICommand {
             throw new AbortException("No such device found: "+device);
 
         TaskListener listener = new StreamTaskListener(stdout,getClientCharset());
-        for (String ipa : files) {
-            FilePath p = new FilePath(checkChannel(),ipa);
-            listener.getLogger().println("Deploying "+ipa);
-            File t = File.createTempFile("jenkins","ipa");
-            try {
-                p.copyTo(new FilePath(t));
-                dev.deploy(t,listener);
-            } finally {
-                t.delete();
-            }
+        for (String bundle : files) {
+            FilePath p = new FilePath(checkChannel(), bundle);
+            listener.getLogger().println("Deploying "+ bundle);
+            dev.deploy(new File(p.getRemote()), listener);
         }
         return 0;
     }

--- a/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDevice.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDevice.java
@@ -71,9 +71,9 @@ public class iOSDevice implements Serializable, ModelObject {
     /**
      * Deploys a .ipa/app file to this device.
      */
-    public void deploy(File bundle, TaskListener listener) throws IOException, InterruptedException {
+    public void deploy(File bundle, String cmdLineArgs, TaskListener listener) throws IOException, InterruptedException {
         Jenkins.getInstance().checkPermission(iOSDeviceList.DEPLOY);
-        computer.getChannel().call(new DeployTask(this, bundle, listener));
+        computer.getChannel().call(new DeployTask(this, bundle, cmdLineArgs, listener));
         computer.getChannel().syncLocalIO();    // TODO: verify if needed
     }
 
@@ -84,7 +84,8 @@ public class iOSDevice implements Serializable, ModelObject {
         StringWriter w = new StringWriter();
         try {
             req.getFileItem("ipa").write(f);
-            deploy(f,new StreamTaskListener(w));
+            String args = req.getSubmittedForm().getString("args");
+            deploy(f, args, new StreamTaskListener(w));
             return HttpResponses.forwardToView(this,"ok").with("msg",w.toString());
         } catch (Exception e) {
             // failed to deploy

--- a/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDevice.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDevice.java
@@ -69,16 +69,18 @@ public class iOSDevice implements Serializable, ModelObject {
     }
 
     /**
-     * Deploys the *.ipa file to this device.
+     * Deploys a .ipa/app file to this device.
      */
-    public void deploy(File ipa, TaskListener listener) throws IOException, InterruptedException {
+    public void deploy(File bundle, TaskListener listener) throws IOException, InterruptedException {
         Jenkins.getInstance().checkPermission(iOSDeviceList.DEPLOY);
-        computer.getChannel().call(new DeployTask(this,ipa,listener));
+        computer.getChannel().call(new DeployTask(this, bundle, listener));
         computer.getChannel().syncLocalIO();    // TODO: verify if needed
     }
 
     public HttpResponse doDoDeploy(StaplerRequest req) throws IOException {
-        File f = File.createTempFile("jenkins","ipa");
+        // The web interface can only support uploading self-contained .ipa files,
+        // not .app directory bundles, so give the temporary file a .ipa suffix
+        File f = File.createTempFile("jenkins",".ipa");
         StringWriter w = new StringWriter();
         try {
             req.getFileItem("ipa").write(f);

--- a/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDeviceList.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDeviceList.java
@@ -160,14 +160,14 @@ public class iOSDeviceList implements RootAction, ModelObject {
         }
 
         public List<iOSDevice> call() throws IOException {
-            try {
-                if (!Platform.isMac())
-                    return Collections.emptyList();
+            if (!Platform.isMac())
+                return Collections.emptyList();
 
+            File exe = File.createTempFile("ios","list");
+            try {
                 PrintStream logger = listener.getLogger();
                 logger.println("Listing up iOS Devices");
 
-                File exe = File.createTempFile("ios","list");
                 FileUtils.copyURLToFile(getClass().getResource("list"),exe);
                 LIBC.chmod(exe.getAbsolutePath(),0755);
 
@@ -183,6 +183,8 @@ public class iOSDeviceList implements RootAction, ModelObject {
                 return parseOutput(logger, out);
             } catch (InterruptedException e) {
                 throw new IOException2("Interrupted while listing up devices",e);
+            } finally {
+                exe.delete();
             }
         }
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,3 @@
 <div>
-    Talks to iOS devices connected to slaves and do stuff.
+    Talks to iOS devices connected to slaves and does stuff.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/config.groovy
@@ -2,7 +2,7 @@ package org.jenkinsci.plugins.ios.connector.DeployBuilder
 
 def f = namespace(lib.FormTagLib)
 
-f.entry(title:"Path of IPA files", field:"path") {
+f.entry(title:"Path to .ipa/app file(s)", field:"path") {
     f.textbox()
 }
 f.entry(title:"Device", field:"udid") {

--- a/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/config.groovy
@@ -8,3 +8,9 @@ f.entry(title:"Path to .ipa/app file(s)", field:"path") {
 f.entry(title:"Device", field:"udid") {
     f.textbox()
 }
+f.advanced() {
+    f.entry(title:"Fruitstrap args", field:"cmdLineArgs",
+            description:"Command line arguments which will be passed to the <tt>fruitstrap</tt> command") {
+        f.textbox()
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/help-path.html
+++ b/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/help-path.html
@@ -1,4 +1,4 @@
 <div>
-    Specify the IPA file(s) to deploy to the phone.
+    Specify the .ipa or .app file(s) to deploy to the phone.
     To specify files, use wildcards like <tt>**/*.ipa</tt>
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/help-udid.html
+++ b/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/help-udid.html
@@ -1,5 +1,5 @@
 <div>
-    Specify the device unique ID of the iOS device to deploy the IPA file to.
+    Specify the device unique ID of the iOS device to deploy the bundle to.
     This device must be USB-connected to one of the slaves in this Jenkins, but
     it need not be connected to the same slave that's executing the build.
 

--- a/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/ios/connector/DeployBuilder/help.html
@@ -1,4 +1,4 @@
 <div>
-    Deploy iOS aplications to any iOS devices USB-tethered in any
+    Deploy iOS aplications to any iOS devices USB-tethered to any
     of the Jenkins slaves.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/ios/connector/iOSDevice/deploy.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/ios/connector/iOSDevice/deploy.groovy
@@ -10,12 +10,16 @@ l.layout {
     l.main_panel {
         h1 {
             img(src:"${resURL}/plugin/ios-device-connector/icons/48x48/iphone.png",alt:"[!]",height:48,width:48)
-            text " ${title} (${my.displayName})"
+            text " ${title} (${my.productTypeDisplayName})"
         }
 
         f.form(method:"POST",action:"doDeploy") {
             f.entry(title:"IPA file to deploy") {
                 input(name:"ipa",type:"file")
+            }
+            f.entry(title:"Fruitstrap args",
+                    description:"Command line arguments which will be passed to the <tt>fruitstrap</tt> command") {
+                f.textbox(name:"args")
             }
             f.block {
                     f.submit(value:"Deploy")


### PR DESCRIPTION
Kohsuke, this is a great plugin!

We wanted a few new features:
- To deploy .app files without having to package them inside a .ipa file, so we added support for both.
- To use the plugin in matrix builds, so we added variable expansion.
- To pass arbitrary arguments to `fruitstrap`, so we added that.

I tested all the changes (deploy via builder, CLI command, and model object) from a Linux master against a Mac slave.  The builder is also being used on our Mac master.  Everything worked well with both .app and .ipa files.

I also made sure that the `list` binary is deleted after querying for devices, as I saw temporary copies of that accumulating on the slave.
