### PR TITLE
Add product type mappings for iPad 4, iPad mini and iPods.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDevice.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDevice.java
@@ -20,6 +20,10 @@ import java.util.Properties;
  * @author Kohsuke Kawaguchi
  */
 public class iOSDevice implements Serializable, ModelObject {
+
+    /** Device property key: product type. */
+    static final String PROP_PRODUCT_TYPE = "ProductType";
+
     /**
      * Which computer is this connected to?
      */
@@ -60,7 +64,7 @@ public class iOSDevice implements Serializable, ModelObject {
      * such as "iPhone 3GS", etc.
      */
     public String getProductTypeDisplayName() {
-        String name = props.getProperty("ProductType");
+        String name = props.getProperty(PROP_PRODUCT_TYPE);
         for (int i=0; i<PRODUCT_TYPE_MAP.length; i+=2) {
             if (name.startsWith(PRODUCT_TYPE_MAP[i]))
                 return PRODUCT_TYPE_MAP[i+1];
@@ -104,8 +108,20 @@ public class iOSDevice implements Serializable, ModelObject {
             "iPhone5,",     "iPhone 5",
 
             "iPad1,",       "iPad 1",
+            "iPad2,5",      "iPad mini",
+            "iPad2,6",      "iPad mini",
+            "iPad2,7",      "iPad mini",
             "iPad2,",       "iPad 2",
-            "iPad3,",       "iPad 3"
+            "iPad3,4",      "iPad 4",
+            "iPad3,5",      "iPad 4",
+            "iPad3,6",      "iPad 4",
+            "iPad3,",       "iPad 3",
+
+            "iPod1,",       "iPod 1G",
+            "iPod2,",       "iPod 2G",
+            "iPod3,",       "iPod 3G",
+            "iPod4,",       "iPod 4G",
+            "iPod5,",       "iPod 5G"
     };
 
     private static final long serialVersionUID = 1L;

--- a/src/test/java/org/jenkinsci/plugins/ios/connector/iOSDeviceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ios/connector/iOSDeviceTest.java
@@ -1,0 +1,46 @@
+package org.jenkinsci.plugins.ios.connector;
+
+import junit.framework.TestCase;
+
+import java.util.Properties;
+
+public class iOSDeviceTest extends TestCase {
+
+    public void testProductTypeMapping_iPhone() {
+        assertProductTypeMapping("iPhone 3G", "iPhone1,2");
+        assertProductTypeMapping("iPhone 5", "iPhone5,");
+        assertProductTypeMapping("iPhone 5", "iPhone5,99");
+    }
+
+    public void testProductTypeMapping_iPad2() {
+        // Only certain 2.x devices are the iPad 2
+        assertProductTypeMapping("iPad 2", "iPad2,4");
+        assertProductTypeMapping("iPad mini", "iPad2,6");
+        assertProductTypeMapping("iPad 2", "iPad2,8");
+    }
+
+    public void testProductTypeMapping_iPad3() {
+        // Only certain 3.x devices are the iPad 3
+        assertProductTypeMapping("iPad 3", "iPad3,3");
+        assertProductTypeMapping("iPad 4", "iPad3,5");
+        assertProductTypeMapping("iPad 3", "iPad3,7");
+    }
+
+    public void testProductTypeMapping_unknown() {
+        // If we don't have a mapping, return the original string
+        assertProductTypeMapping("", "");
+        assertProductTypeMapping("foo", "foo");
+        assertProductTypeMapping("iDroid4,2", "iDroid4,2");
+    }
+
+    private static void assertProductTypeMapping(String expectedDisplayName, String productType) {
+        assertNotNull(productType);
+        assertNotNull(expectedDisplayName);
+
+        Properties props = new Properties();
+        props.put(iOSDevice.PROP_PRODUCT_TYPE, productType);
+        iOSDevice device = new iOSDevice(props);
+        assertEquals(expectedDisplayName, device.getProductTypeDisplayName());
+    }
+
+}


### PR DESCRIPTION
Tested on our iPad mini ;)

Plus I added unit tests.
