### PR TITLE
Add dynamic matrix axis which populates with all connected UDIDs at build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.466</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>1.480</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/ios/connector/matrix/AvailableDevicesAxis.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/matrix/AvailableDevicesAxis.java
@@ -1,0 +1,69 @@
+// Copyright © 2012 iosphere GmbH
+package org.jenkinsci.plugins.ios.connector.matrix;
+
+import org.jenkinsci.plugins.ios.connector.Messages;
+import org.jenkinsci.plugins.ios.connector.iOSDevice;
+import org.jenkinsci.plugins.ios.connector.iOSDeviceList;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.Extension;
+import hudson.matrix.Axis;
+import hudson.matrix.AxisDescriptor;
+import hudson.matrix.MatrixBuild.MatrixBuildExecution;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import jenkins.model.Jenkins;
+
+/** Dynamic matrix axis which expands to the UDID of every connected iOS device at build time. */
+public class AvailableDevicesAxis extends Axis {
+
+    /** Variable name under which each device UDID will be made available. */
+    private static final String AXIS_NAME = "UDID";
+
+    @Inject
+    private transient iOSDeviceList deviceList;
+
+    private List<String> axisValues;
+
+    @DataBoundConstructor
+    public AvailableDevicesAxis() {
+        super(AXIS_NAME, AXIS_NAME);
+    }
+
+    @Override
+    public List<String> getValues() {
+        if (axisValues == null || axisValues.isEmpty()) {
+            return Collections.singletonList("default");
+        }
+        return axisValues;
+    }
+
+    @Override
+    public List<String> rebuild(MatrixBuildExecution context) {
+        Jenkins.getInstance().getInjector().injectMembers(this);
+
+        List<String> udids = new ArrayList<String>();
+        if (deviceList != null) {
+            for (iOSDevice device : deviceList.getDevices().values()) {
+                udids.add(device.getUniqueDeviceId());
+            }
+        }
+
+        axisValues = udids;
+        return udids;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends AxisDescriptor {
+        @Override
+        public String getDisplayName() {
+            return Messages.AvailableDevicesAxis_Name();
+        }
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/ios/connector/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/ios/connector/Messages.properties
@@ -1,3 +1,4 @@
+AvailableDevicesAxis.Name=All available iOS devices
 iOSDeviceList.PermissionGroup.Title=iOS devices
 iOSDeviceList.DeployPermission=Deploy apps
 iOSDeviceList.ReadPermission=Read device info

--- a/src/main/resources/org/jenkinsci/plugins/ios/connector/matrix/AvailableDevicesAxis/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/ios/connector/matrix/AvailableDevicesAxis/help.html
@@ -1,0 +1,1 @@
+Provides a dynamically-populated axis called <tt>UDID</tt>, containing the unique device ID of <a href="${rootURL}/ios-devices" target="_blank">every iOS device connected to Jenkins</a> at the time a build is started.


### PR DESCRIPTION
We have various jobs with a matrix axis containing a list of hardcoded UDIDs.

This is ugly, and fragile, if somebody ever happens to unplug a device from the Jenkins cluster.

So... this adds a dynamic matrix axis which, at build time, gathers all the _currently-available_ UDIDs.

I upped the POM requirement to 1.480, as the dynamic matrix stuff was added around ~1.471 but I believe had some bugs in the following few versions, and 1.480 is an LTS version.
