### PR TITLE
[JENKINS-15578] Fail gracefully if slave doesn't have permission.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDeviceList.java
+++ b/src/main/java/org/jenkinsci/plugins/ios/connector/iOSDeviceList.java
@@ -88,7 +88,11 @@ public class iOSDeviceList implements RootAction, ModelObject {
     }
 
     public void update(Computer c, TaskListener listener) {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        if (!Jenkins.getInstance().hasPermission(Jenkins.READ)) {
+            listener.getLogger().println("This node does not have read permission; " +
+                "this is required to check for connected iOS devices.");
+            return;
+        }
 
         List<iOSDevice> r = Collections.emptyList();
         if (c.isOnline()) {// ignore disabled slaves


### PR DESCRIPTION
I'm really not clear on how permissions work regarding launching slaves, and whether the `ADMINISTER` permission is really necessary to execute the iOS device `list` binary.

Kohsuke feedback required! :)

But here's a quick patch for [JENKINS-15578](https://issues.jenkins-ci.org/browse/JENKINS-15578), tested on a JNLP OS X slave in a Jenkins with security enabled.
